### PR TITLE
Updated conv.rs so that "Convolution done..." is only printed in debug builds

### DIFF
--- a/src/conv.rs
+++ b/src/conv.rs
@@ -62,8 +62,10 @@ fn convolve(img_padded: &PhotonImage, filter: &Filter, width_conv: u32, height_c
         img_conv.push(255_u8);
         img_conv.push(255_u8);
     }
-
+    
+    #[cfg(debug_assertions)]    
     println!("Convolution done...");
+    
     PhotonImage::new(img_conv, width_conv, height_conv)
 }
 

--- a/src/conv.rs
+++ b/src/conv.rs
@@ -62,10 +62,10 @@ fn convolve(img_padded: &PhotonImage, filter: &Filter, width_conv: u32, height_c
         img_conv.push(255_u8);
         img_conv.push(255_u8);
     }
-    
-    #[cfg(debug_assertions)]    
+
+    #[cfg(debug_assertions)]
     println!("Convolution done...");
-    
+
     PhotonImage::new(img_conv, width_conv, height_conv)
 }
 


### PR DESCRIPTION
I would really appreciate the ability to suppress image-conv's output to stdout. If I'm using image-conv as part of another project, I don't want to pollute the output of that other project whenever a convolution happens.
Thanks!